### PR TITLE
Add support for new project-scoped API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ _Overview video_
 
 1. Ensure you have [Node.js](https://nodejs.org) installed.
 2. Load this git project onto your local drive.
-3. Create a name-less file ".env" in the project root and put into it [your OpenAI API](https://platform.openai.com/api-keys) key by writing: _OPENAI_API_KEY=yourapikey_
-4. Navigate to the project via the command line, and type *npm install*
-5. Then in the same command line, type *npm start*
-6. Open http://localhost:3000 in your browser. Have fun!
+3. Create a name-less file ".env" in the project root and put into it [your OpenAI API](https://platform.openai.com/api-keys) key by writing: OPENAI_API_KEY=yourapikey
+4. If your API key is scoped to a specific project, then also add OPENAI_ORGANIZATION=org-... and OPENAI_PROJECT=proj_... values to the .env file
+5. Navigate to the project via the command line, and type *npm install*
+6. Then in the same command line, type *npm start*
+7. Open http://localhost:3000 in your browser. Have fun!
 
 _This project makes no guarantees for being bug-free, use at your own risk, and keep in mind that API calls cost money (see the [OpenAI costs dashboard](https://platform.openai.com/usage) and the [pricing table](https://openai.com/pricing))._
 

--- a/server.js
+++ b/server.js
@@ -18,6 +18,8 @@ const defaultModel = "dall-e-3";
 const model = process.env.MODEL ? process.env.MODEL : defaultModel;
 const saveJsonWithImages = process.env.SAVE_JSON_WITH_IMAGES === 'true';
 const port = process.env.PORT ? process.env.PORT : 3000;
+const openAiOrganization = process.env.OPENAI_ORGANIZATION ? process.env.OPENAI_ORGANIZATION : undefined;
+const openAiProject = process.env.OPENAI_PROJECT ? process.env.OPENAI_PROJECT : undefined;
 
 const parsedMaxImagesValue = parseInt(process.env.MAX_IMAGES_TO_SERVE_AT_START, 10);
 const maxImagesToServeAtStart = parsedMaxImagesValue > 0 ? parsedMaxImagesValue : 1000;
@@ -67,6 +69,8 @@ app.post('/generate-image', async (req, res) => {
       headers: {
         'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
         'Content-Type': 'application/json',
+        ...(openAiOrganization && {'OpenAI-Organization': openAiOrganization}),
+        ...(openAiProject && {'OpenAI-Project': openAiProject}),
       },
       body: JSON.stringify({
         prompt: prompt,


### PR DESCRIPTION
Adds support for API keys that are bound to a specific project:

https://help.openai.com/en/articles/9186755-managing-projects-in-the-api-platform

Without providing these extra credentials, I get an "invalid_request_error" error from the server