### PR TITLE
Fix "unknown parameter" errors for DALL-E-2

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,12 +73,12 @@ app.post('/generate-image', async (req, res) => {
         ...(openAiProject && {'OpenAI-Project': openAiProject}),
       },
       body: JSON.stringify({
-        prompt: prompt,
         n: 1,
-        size: size,
-        style: style,
-        quality: quality,
-        model: model
+        prompt,
+        size,
+        model,
+        ...(model !== "dall-e-2" && {style}),
+        ...(model !== "dall-e-2" && {quality}),
       }),
     });
 


### PR DESCRIPTION
DALL-E 2 gives a fatal error if either the style or quality parameters are included in the request, e.g.:

```js
  error: {
    message: "Unknown parameter: 'style'.",
    type: 'invalid_request_error',
    param: 'style',
    code: 'unknown_parameter'
  }
```

This fix avoids sending those if DALL-E 2 is selected